### PR TITLE
I seg qt4 example

### DIFF
--- a/.vscode/.cmaketools.json
+++ b/.vscode/.cmaketools.json
@@ -1,0 +1,5 @@
+{
+  "variant": null,
+  "activeEnvironments": [],
+  "codeModel": null
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "null",
+            "includePath": [],
+            "defines": [],
+            "browse": {
+                "path": [],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/iSeg/CMakeLists.txt
+++ b/iSeg/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(ViewerSrcs
 	SmoothingWidget.cpp
 	SurfaceViewerWidget.cpp
 	ThresholdWidget.cpp
+	ThresholdWidgetQt4.cpp
 	TissueCleaner.cpp
 	TissueHierarchy.cpp
 	TissueInfos.cpp
@@ -117,6 +118,7 @@ SET(MyMocHeaders
 	SurfaceViewerWidget.h
 	TissueTreeWidget.h
 	ThresholdWidget.h
+	ThresholdWidgetQt4.h
 	TransformWidget.h
 	UndoConfigurationDialog.h
 	VesselWidget.h
@@ -133,6 +135,7 @@ ENDIF()
 
 SET(UIS
 	Settings.ui
+	ThresholdWidgetQt4.ui
 )
 
 SET(RCCS images.qrc)

--- a/iSeg/CMakeLists.txt
+++ b/iSeg/CMakeLists.txt
@@ -66,8 +66,7 @@ SET(ViewerSrcs
 	SliceTransform.cpp
 	SliceViewerWidget.cpp
 	SmoothingWidget.cpp
-	SurfaceViewerWidget.cpp
-	ThresholdWidget.cpp
+	SurfaceViewerWidget.cpp	
 	ThresholdWidgetQt4.cpp
 	TissueCleaner.cpp
 	TissueHierarchy.cpp
@@ -116,8 +115,7 @@ SET(MyMocHeaders
 	SliceViewerWidget.h
 	SmoothingWidget.h
 	SurfaceViewerWidget.h
-	TissueTreeWidget.h
-	ThresholdWidget.h
+	TissueTreeWidget.h	
 	ThresholdWidgetQt4.h
 	TransformWidget.h
 	UndoConfigurationDialog.h

--- a/iSeg/MainWindow.cpp
+++ b/iSeg/MainWindow.cpp
@@ -34,7 +34,6 @@
 #include "SmoothingWidget.h"
 #include "StdStringToQString.h"
 #include "SurfaceViewerWidget.h"
-#include "ThresholdWidget.h"
 #include "ThresholdWidgetQt4.h"
 #include "TissueCleaner.h"
 #include "TissueInfos.h"
@@ -613,10 +612,8 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring,
 	lb_inactivewarning = new QLabel("  3D Inactive Slice!  ", this);
 	lb_inactivewarning->setStyleSheet("QLabel  { color: red; }");
 
-	threshold_widget = new ThresholdWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
+	threshold_widget = new ThresholdWidgetQt4(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
 	tabwidgets.push_back(threshold_widget);
-	threshold_widget_qt4 = new ThresholdWidgetQt4(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
-	tabwidgets.push_back(threshold_widget_qt4);
 	hyst_widget = new HystereticGrowingWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
 	tabwidgets.push_back(hyst_widget);
 	livewire_widget = new LivewireWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);

--- a/iSeg/MainWindow.cpp
+++ b/iSeg/MainWindow.cpp
@@ -35,6 +35,7 @@
 #include "StdStringToQString.h"
 #include "SurfaceViewerWidget.h"
 #include "ThresholdWidget.h"
+#include "ThresholdWidgetQt4.h"
 #include "TissueCleaner.h"
 #include "TissueInfos.h"
 #include "TissueTreeWidget.h"
@@ -614,6 +615,8 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring,
 
 	threshold_widget = new ThresholdWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
 	tabwidgets.push_back(threshold_widget);
+	threshold_widget_qt4 = new ThresholdWidgetQt4(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
+	tabwidgets.push_back(threshold_widget_qt4);
 	hyst_widget = new HystereticGrowingWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);
 	tabwidgets.push_back(hyst_widget);
 	livewire_widget = new LivewireWidget(handler3D, nullptr, "new window", Qt::WDestructiveClose | Qt::WResizeNoErase);

--- a/iSeg/MainWindow.h
+++ b/iSeg/MainWindow.h
@@ -72,6 +72,7 @@ class VesselWidget;
 class WatershedWidget;
 class SmoothingWidget;
 class ThresholdWidget;
+class ThresholdWidgetQt4;
 class MeasurementWidget;
 class ImageViewerWidget;
 class SurfaceViewerWidget;
@@ -223,6 +224,7 @@ private:
 	QCheckBox* tissue3Dopt;
 	QStackedWidget* methodTab;
 	ThresholdWidget* threshold_widget;
+	ThresholdWidgetQt4* threshold_widget_qt4;
 	MeasurementWidget* measurement_widget;
 	VesselWidget* vesselextr_widget;
 	SmoothingWidget* smoothing_widget;

--- a/iSeg/MainWindow.h
+++ b/iSeg/MainWindow.h
@@ -223,8 +223,7 @@ private:
 	std::vector<Q3Action*> showtab_action;
 	QCheckBox* tissue3Dopt;
 	QStackedWidget* methodTab;
-	ThresholdWidget* threshold_widget;
-	ThresholdWidgetQt4* threshold_widget_qt4;
+	ThresholdWidgetQt4* threshold_widget;
 	MeasurementWidget* measurement_widget;
 	VesselWidget* vesselextr_widget;
 	SmoothingWidget* smoothing_widget;

--- a/iSeg/ThresholdWidgetQt4.cpp
+++ b/iSeg/ThresholdWidgetQt4.cpp
@@ -1,0 +1,756 @@
+/*
+ * Copyright (c) 2018 The Foundation for Research on Information Technologies in Society (IT'IS).
+ * 
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ * 
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+
+#include "ThresholdWidgetQt4.h"
+#include "SlicesHandler.h"
+#include "bmp_read_1.h"
+#include <QSignalMapper>
+#include <QFileDialog>
+#include <QDoubleValidator>
+
+using namespace iseg;
+
+
+ThresholdWidgetQt4::ThresholdWidgetQt4(SlicesHandler* hand3D, 
+										QWidget *parent, 
+										const char* name, 
+										Qt::WindowFlags wFlags):
+WidgetInterface(parent, name, wFlags), 
+handler3D(hand3D)
+{
+	activeslice = handler3D->active_slice();
+	bmphand = handler3D->get_activebmphandler();
+
+	initUi();	
+	updateUi();
+}
+
+ThresholdWidgetQt4::~ThresholdWidgetQt4()
+{
+
+}
+
+void ThresholdWidgetQt4::init()
+{
+	if (activeslice != handler3D->active_slice())
+	{
+		activeslice = handler3D->active_slice();
+		bmphand = handler3D->get_activebmphandler();
+		auto range = get_range();
+		auto range_validator = new QDoubleValidator(range.first, range.second, 1000, ui.mThresholdBorderLineEdit);
+		ui.mThresholdBorderLineEdit->setValidator(range_validator);
+
+		threshs[0] = float(ui.mManualNrTissuesSpinBox->value() - 1);
+		for (unsigned i = 0; i < 20; ++i)
+		{
+			bits1[i] = 0;
+			threshs[i + 1] = range.second;
+			weights[i] = 1.0f;
+		}
+	}
+	else {
+		bmphand = handler3D->get_activebmphandler();
+		auto range = get_range();
+		for (unsigned i = 0; i < 20; i++)
+		{
+			if (threshs[i + 1] > range.second)
+				threshs[i + 1] = range.second;
+			if (threshs[i + 1] < range.first)
+				threshs[i + 1] = range.first;
+		}
+	}
+
+	
+	updateUi();
+}
+
+void ThresholdWidgetQt4::newloaded()
+{
+	init();
+}
+
+void ThresholdWidgetQt4::hideparams_changed()
+{
+	init();
+}
+
+FILE* ThresholdWidgetQt4::SaveParams(FILE* fp, int version)
+{
+	if (version >= 2)
+	{
+		int dummy;
+		dummy = slider->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = ratio->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_nrtissues->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_dim->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_tissuenr->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_px->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_py->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_lx->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_ly->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_iternr->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_converge->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = sb_minpix->value();
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(subsect->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(rb_manual->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(rb_histo->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(rb_kmeans->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(rb_EM->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+		dummy = (int)(allslices->isOn());
+		fwrite(&(dummy), 1, sizeof(int), fp);
+
+		fwrite(&upper, 1, sizeof(float), fp);
+		fwrite(&lower, 1, sizeof(float), fp);
+		fwrite(threshs, 21, sizeof(float), fp);
+		fwrite(weights, 20, sizeof(float), fp);
+	}
+
+	return fp;
+}
+
+FILE* ThresholdWidgetQt4::LoadParams(FILE* fp, int version)
+{
+	if (version >= 2)
+	{
+		QObject::disconnect(sb_nrtissues, SIGNAL(valueChanged(int)), this,
+			SLOT(nrtissues_changed(int)));
+		QObject::disconnect(sb_dim, SIGNAL(valueChanged(int)), this,
+			SLOT(dim_changed(int)));
+		QObject::disconnect(sb_tissuenr, SIGNAL(valueChanged(int)), this,
+			SLOT(tissuenr_changed(int)));
+		QObject::disconnect(slider, SIGNAL(sliderMoved(int)), this,
+			SLOT(slider_changed(int)));
+		QObject::disconnect(le_borderval, SIGNAL(returnPressed()), this,
+			SLOT(le_borderval_returnpressed()));
+		QObject::disconnect(subsect, SIGNAL(clicked()), this,
+			SLOT(subsect_toggled()));
+		QObject::disconnect(modegroup, SIGNAL(buttonClicked(int)), this,
+			SLOT(method_changed(int)));
+
+		int dummy;
+		fread(&dummy, sizeof(int), 1, fp);
+		slider->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		ratio->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_nrtissues->setValue(dummy);
+		sb_tissuenr->setMaxValue(dummy - 1);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_dim->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_tissuenr->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_px->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_py->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_lx->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_ly->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_iternr->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_converge->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		sb_minpix->setValue(dummy);
+		fread(&dummy, sizeof(int), 1, fp);
+		subsect->setChecked(dummy > 0);
+		fread(&dummy, sizeof(int), 1, fp);
+		rb_manual->setChecked(dummy > 0);
+		fread(&dummy, sizeof(int), 1, fp);
+		rb_histo->setChecked(dummy > 0);
+		fread(&dummy, sizeof(int), 1, fp);
+		rb_kmeans->setChecked(dummy > 0);
+		fread(&dummy, sizeof(int), 1, fp);
+		rb_EM->setChecked(dummy > 0);
+		fread(&dummy, sizeof(int), 1, fp);
+		allslices->setChecked(dummy > 0);
+
+		fread(&upper, sizeof(float), 1, fp);
+		fread(&lower, sizeof(float), 1, fp);
+		fread(threshs, sizeof(float), 21, fp);
+		fread(weights, sizeof(float), 20, fp);
+
+		dummy = sb_tissuenr->value();
+		method_changed(0);
+		subsect_toggled();
+		nrtissues_changed(sb_nrtissues->value());
+		dim_changed(sb_dim->value());
+		sb_tissuenr->setValue(dummy);
+		on_tissuenr_changed(dummy);
+
+		QObject::connect(subsect, SIGNAL(clicked()), this,
+			SLOT(subsect_toggled()));
+		QObject::connect(modegroup, SIGNAL(buttonClicked(int)), this,
+			SLOT(method_changed(int)));
+		QObject::connect(sb_nrtissues, SIGNAL(valueChanged(int)), this,
+			SLOT(nrtissues_changed(int)));
+		QObject::connect(sb_dim, SIGNAL(valueChanged(int)), this,
+			SLOT(dim_changed(int)));
+		QObject::connect(sb_tissuenr, SIGNAL(valueChanged(int)), this,
+			SLOT(tissuenr_changed(int)));
+		QObject::connect(slider, SIGNAL(sliderMoved(int)), this,
+			SLOT(slider_changed(int)));
+		QObject::connect(le_borderval, SIGNAL(returnPressed()), this,
+			SLOT(le_borderval_returnpressed()));
+	}
+	return fp;
+}
+
+void ThresholdWidgetQt4::on_mManualNrTissuesSpinBox_valueChanged(int newValue)
+{
+	threshs[0] = float(newValue - 1);
+	ui.mManualLimitNrSpinBox->setMaxValue(newValue - 1);
+
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mManualLimitNrSpinBox_valueChanged(int newValue)
+{
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mLoadBordersPushButton_clicked()
+{
+	auto loadfilename =
+		QFileDialog::getOpenFileName(this, "Select Boarder file", QString::null,
+			"Boarders (*.txt)\n"
+			"All (*.*)");
+
+	if (loadfilename.isEmpty()) {
+		return;
+	}
+
+	std::vector<float> fvec;
+	// hope it's only american english... ;)
+	FILE* fp = fopen(loadfilename.ascii(), "r");
+	float f;
+	if (fp != nullptr)
+	{
+		while (fscanf(fp, "%f", &f) == 1)
+		{
+			fvec.push_back(f);
+		}
+	}
+	fclose(fp);
+
+	if (fvec.size() > 0 && fvec.size() < 20)
+	{
+		ui.mManualNrTissuesSpinBox->setValue(static_cast<int>(fvec.size() + 1));
+		threshs[0] = float(fvec.size());
+		ui.mManualLimitNrSpinBox->setMaxValue(static_cast<int>(fvec.size()));
+
+		auto range = get_range();
+		for (unsigned i = 0; i < (unsigned)fvec.size(); i++)
+		{
+			if (fvec[i] > range.second)
+				f = range.second;
+			else if (fvec[i] < range.first)
+				f = range.first;
+			else
+				f = fvec[i];
+			threshs[i + 1] = f;
+		}
+		ui.mManualLimitNrSpinBox->setValue(1);
+	}
+
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mSaveBordersPushButton_clicked()
+{
+	auto savefilename = QFileDialog::getSaveFileName(this, "Save file",
+		QString::null, "Boarders (*.txt)\n");
+
+	if (savefilename.length() > 4 && !savefilename.endsWith(QString(".txt")))
+		savefilename.append(".txt");
+
+	if (!savefilename.isEmpty())
+	{
+		FILE* fp = fopen(savefilename.ascii(), "w");
+		for (int i = 1; i <= ui.mManualLimitNrSpinBox->maxValue(); i++)
+			fprintf(fp, "%f\n", threshs[i]);
+		fclose(fp);
+	}
+}
+
+void ThresholdWidgetQt4::on_mThresholdHorizontalSlider_valueChanged(int newValue)
+{
+	auto range = get_range();
+	threshs[ui.mManualLimitNrSpinBox->value()] =
+		newValue * 0.005f * (range.second - range.first) + range.first;
+
+	if (ui.mAllSlicesCheckBox->isChecked())
+		handler3D->threshold(threshs);
+	else
+		bmphand->threshold(threshs);
+
+	emit end_datachange(this, iseg::NoUndo);
+
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mThresholdBorderLineEdit_editingFinished()
+{
+	bool b1;
+	float val = ui.mThresholdBorderLineEdit->text().toFloat(&b1);
+	if (b1)
+	{
+		threshs[ui.mManualLimitNrSpinBox->value()] = val;
+		{
+			iseg::DataSelection dataSelection;
+			dataSelection.allSlices = ui.mAllSlicesCheckBox->isChecked();
+			dataSelection.sliceNr = handler3D->active_slice();
+			dataSelection.work = true;
+			emit begin_datachange(dataSelection, this);
+
+			if (ui.mAllSlicesCheckBox->isChecked())
+				handler3D->threshold(threshs);
+			else
+				bmphand->threshold(threshs);
+
+			emit end_datachange(this);
+		}
+	}
+
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mHistoPxSpinBox_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mHistoLxSpinBox_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mHistoPySpinBox_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mHistoLySpinBox_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mHistoMinPixelsSpinBox_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mHistoMinPixelsRatioHorizontalSlider_valueChanged(int newValue)
+{
+	// nothing done
+}
+
+void ThresholdWidgetQt4::on_mKMeansNrTissuesSpinBox_valueChanged(int newValue)
+{	
+}
+
+void ThresholdWidgetQt4::on_mKMeansDimsSpinBox_valueChanged(int newValue)
+{
+	const size_t cursize = filenames.size();
+	if (newValue > cursize + 1)
+	{
+		filenames.resize(newValue - 1);
+		for (size_t i = cursize; i + 1 < newValue; ++i)
+			filenames[i] = QString("");
+	}
+
+	ui.mKMeansImageNrSpinBox->setMaxValue(newValue);
+	ui.mKMeansImageNrSpinBox->setValue(1);
+	
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mKMeansImageNrSpinBox_valueChanged(int newValue)
+{
+	updateUi();	
+}
+
+void ThresholdWidgetQt4::on_mKMeansWeightHorizontalSlider_valueChanged(int newValue)
+{
+}
+
+void ThresholdWidgetQt4::on_mKMeansFilenameLineEdit_editingFinished()
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansFilenamePushButton_clicked()
+{
+	QString loadfilename = QFileDialog::getOpenFileName(this, "Select an image"
+		QString::null,
+		"Images (*.png)\n"
+		"Images (*.mhd)\n"
+		"All (*.*)" //"Images (*.bmp)\n" "All (*.*)", QString::null,
+		);			//, filename);
+	ui.mKMeansFilenameLineEdit_2->setText(loadfilename);
+	filenames[ui.mKMeansImageNrSpinBox->value() - 2] = loadfilename;
+
+	ui.mKMeansRRadioButton_2->setEnabled(false);
+	ui.mKMeansGRadioButton_2->setEnabled(false);
+	ui.mKMeansBRadioButton_2->setEnabled(false);
+	ui.mKMeansARadioButton_2->setEnabled(false);
+
+	QFileInfo fi(loadfilename);
+	QString ext = fi.extension();
+	if (ext == "png")
+	{
+		QImage image(loadfilename);
+
+		if (image.depth() > 8)
+		{
+			ui.mKMeansRRadioButton_2->setEnabled(true);
+			ui.mKMeansGRadioButton_2->setEnabled(true);
+			ui.mKMeansBRadioButton_2->setEnabled(true);
+			if (image.hasAlphaChannel())
+				ui.mKMeansARadioButton_2->setEnabled(true);
+		}
+	}
+}
+
+void ThresholdWidgetQt4::on_mKMeansRRadioButton_clicked()
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansGRadioButton_clicked()
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansBRadioButton_clicked()
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansARadioButton_clicked()
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansIterationsSpinBox_valueChanged(int newValue)
+{
+
+}
+
+void ThresholdWidgetQt4::on_mKMeansConvergeSpinBox_valueChanged(int newValue)
+{
+
+}
+
+void ThresholdWidgetQt4::on_mUseCenterFileCheckBox_toggled(bool newValue)
+{
+	if (!newValue) {
+		ui.mCenterFilenameLineEdit->setText("");
+	}
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_mCenterFilenameLineEdit_editingFinished()
+{
+	// never happens
+}
+
+void ThresholdWidgetQt4::on_mSelectCenterFilenamePushButton_clicked()
+{
+	auto center_file_name = QFileDialog::getOpenFileName(nullptr,
+		"Select center file", QString(), "Text File (*.txt*)");
+	ui.mCenterFilenameLineEdit->setText(center_file_name);
+}
+
+void ThresholdWidgetQt4::on_mAllSlicesCheckBox_toggled(bool newValue)
+{
+	// does nothing...
+}
+
+void ThresholdWidgetQt4::on_mExecutePushButton_clicked()
+{
+	unsigned char modedummy;
+
+	iseg::DataSelection dataSelection;
+	dataSelection.allSlices = ui.mAllSlicesCheckBox->isChecked();
+	dataSelection.sliceNr = handler3D->active_slice();
+	dataSelection.work = true;
+	emit begin_datachange(dataSelection, this);
+
+	if (ui.mManualModeRadioButton->isChecked())
+	{
+		if (ui.mAllSlicesCheckBox->isChecked())
+			handler3D->threshold(threshs);
+		else
+			bmphand->threshold(threshs);
+	}
+	else if (ui.mHistoModeRadioButton->isChecked())
+	{
+		bmphand->swap_bmpwork();
+
+		if (ui.mSubsectionGroupBox->isChecked())
+		{
+			Point p;
+			p.px = (unsigned short)ui.mHistoPxSpinBox->value();
+			p.py = (unsigned short)ui.mHistoPySpinBox->value();
+			bmphand->make_histogram(p, ui.mHistoLxSpinBox->value(), ui.mHistoLySpinBox->value(), true);
+		}
+		else
+			bmphand->make_histogram(true);
+
+		bmphand->gaussian_hist(1.0f);
+		bmphand->swap_bmpwork();
+
+		float* thresh1 = bmphand->find_modal((unsigned)ui.mHistoMinPixelsSpinBox->value(),
+			0.005f * ui.mHistoMinPixelsRatioHorizontalSlider->value());
+		if (ui.mAllSlicesCheckBox->isChecked())
+			handler3D->threshold(thresh1);
+		else
+			bmphand->threshold(thresh1);
+		free(thresh1);
+	}
+	else if (ui.mKMeansRadioButton->isChecked())
+	{
+		FILE* fp = fopen("C:\\gamma.txt", "r"); // really????
+		if (fp != nullptr)
+		{
+			float** centers = new float*[ui.mKMeansNrTissuesSpinBox->value()];
+			for (int i = 0; i < ui.mKMeansNrTissuesSpinBox->value(); i++)
+				centers[i] = new float[ui.mKMeansDimsSpinBox->value()];
+			float* tol_f = new float[ui.mKMeansDimsSpinBox->value()];
+			float* tol_d = new float[ui.mKMeansDimsSpinBox->value()];
+			for (int i = 0; i < ui.mKMeansNrTissuesSpinBox->value(); i++)
+			{
+				for (int j = 0; j < ui.mKMeansDimsSpinBox->value(); j++)
+					fscanf(fp, "%f", &(centers[i][j]));
+			}
+			for (int j = 0; j < ui.mKMeansDimsSpinBox->value(); j++)
+				fscanf(fp, "%f", &(tol_f[j]));
+			for (int j = 1; j < ui.mKMeansDimsSpinBox->value(); j++)
+				fscanf(fp, "%f", &(tol_d[j]));
+			tol_d[0] = 0.0f;
+			fclose(fp);
+			std::vector<std::string> mhdfiles;
+			for (int i = 0; i + 1 < ui.mKMeansDimsSpinBox->value(); i++)
+				mhdfiles.push_back(std::string(filenames[i].ascii()));
+			if (ui.mAllSlicesCheckBox->isChecked())
+				handler3D->gamma_mhd(handler3D->active_slice(),
+				(short)ui.mKMeansNrTissuesSpinBox->value(),
+					(short)ui.mKMeansDimsSpinBox->value(), mhdfiles, weights,
+					centers, tol_f, tol_d);
+			else
+				bmphand->gamma_mhd(
+				(short)ui.mKMeansNrTissuesSpinBox->value(), (short)ui.mKMeansDimsSpinBox->value(),
+					mhdfiles, handler3D->active_slice(), weights, centers,
+					tol_f, tol_d, handler3D->get_pixelsize());
+			delete[] tol_d;
+			delete[] tol_f;
+			for (int i = 0; i < ui.mKMeansNrTissuesSpinBox->value(); i++)
+				delete[] centers[i];
+			delete[] centers;
+		}
+		else
+		{
+			std::vector<std::string> kmeansfiles;
+			for (int i = 0; i + 1 < ui.mKMeansDimsSpinBox->value(); i++)
+				kmeansfiles.push_back(std::string(filenames[i].ascii()));
+			if (kmeansfiles.size() > 0)
+			{
+				if (kmeansfiles[0].substr(kmeansfiles[0].find_last_of(".") +
+					1) == "png")
+				{
+					std::vector<int> extractChannels;
+					if (ui.mKMeansRRadioButton_2->isChecked())
+						extractChannels.push_back(0);
+					if (ui.mKMeansGRadioButton_2->isChecked())
+						extractChannels.push_back(1);
+					if (ui.mKMeansBRadioButton_2->isChecked())
+						extractChannels.push_back(2);
+					if (ui.mKMeansARadioButton_2->isChecked())
+						extractChannels.push_back(3);
+					if (ui.mKMeansDimsSpinBox->value() != extractChannels.size() + 1)
+						return;
+					if (ui.mAllSlicesCheckBox->isChecked())
+						handler3D->kmeans_png(
+							handler3D->active_slice(),
+							(short)ui.mKMeansNrTissuesSpinBox->value(),
+							(short)ui.mKMeansDimsSpinBox->value(), kmeansfiles,
+							extractChannels, weights,
+							(unsigned int)ui.mKMeansIterationsSpinBox->value(),
+							(unsigned int)ui.mKMeansConvergeSpinBox->value(),
+							ui.mCenterFilenameLineEdit->text().toStdString());
+					else
+						bmphand->kmeans_png(
+						(short)ui.mKMeansNrTissuesSpinBox->value(),
+							(short)ui.mKMeansDimsSpinBox->value(), kmeansfiles,
+							extractChannels, handler3D->active_slice(),
+							weights, (unsigned int)ui.mKMeansIterationsSpinBox->value(),
+							(unsigned int)ui.mKMeansConvergeSpinBox->value(),
+							ui.mCenterFilenameLineEdit->text().toStdString());
+				}
+				else
+				{
+					if (ui.mAllSlicesCheckBox->isChecked())
+						handler3D->kmeans_mhd(
+							handler3D->active_slice(),
+							(short)ui.mKMeansNrTissuesSpinBox->value(),
+							(short)ui.mKMeansDimsSpinBox->value(), kmeansfiles, weights,
+							(unsigned int)ui.mKMeansIterationsSpinBox->value(),
+							(unsigned int)ui.mKMeansConvergeSpinBox->value());
+					else
+						bmphand->kmeans_mhd((short)ui.mKMeansNrTissuesSpinBox->value(),
+						(short)ui.mKMeansDimsSpinBox->value(), kmeansfiles,
+							handler3D->active_slice(),
+							weights,
+							(unsigned int)ui.mKMeansIterationsSpinBox->value(),
+							(unsigned int)ui.mKMeansConvergeSpinBox->value());
+				}
+			}
+			else
+			{
+				if (ui.mAllSlicesCheckBox->isChecked())
+					handler3D->kmeans_mhd(
+						handler3D->active_slice(),
+						(short)ui.mKMeansNrTissuesSpinBox->value(), (short)ui.mKMeansDimsSpinBox->value(),
+						kmeansfiles, weights, (unsigned int)ui.mKMeansIterationsSpinBox->value(),
+						(unsigned int)ui.mKMeansConvergeSpinBox->value());
+				else
+					bmphand->kmeans_mhd((short)ui.mKMeansNrTissuesSpinBox->value(),
+					(short)ui.mKMeansDimsSpinBox->value(), kmeansfiles,
+						handler3D->active_slice(), weights,
+						(unsigned int)ui.mKMeansIterationsSpinBox->value(),
+						(unsigned int)ui.mKMeansConvergeSpinBox->value());
+			}
+		}
+	}
+	else
+	{
+		//		EM em;
+		for (int i = 0; i < ui.mKMeansDimsSpinBox->value(); i++)
+		{
+			if (bits1[i] == 0)
+				bits[i] = bmphand->return_bmp();
+			else
+				bits[i] = bmphand->getstack(bits1[i], modedummy);
+		}
+
+		if (ui.mAllSlicesCheckBox->isChecked())
+			handler3D->em(handler3D->active_slice(),
+			(short)ui.mKMeansNrTissuesSpinBox->value(),
+				(unsigned int)ui.mKMeansIterationsSpinBox->value(),
+				(unsigned int)ui.mKMeansConvergeSpinBox->value());
+		else
+			bmphand->em((short)ui.mKMeansNrTissuesSpinBox->value(), (short)ui.mKMeansDimsSpinBox->value(),
+				bits, weights, (unsigned int)ui.mKMeansIterationsSpinBox->value(),
+				(unsigned int)ui.mKMeansConvergeSpinBox->value());
+	}
+
+	emit end_datachange(this);
+}
+
+void ThresholdWidgetQt4::on_tissuenr_changed(int newValue)
+{
+	updateUi();
+}
+
+void ThresholdWidgetQt4::on_slicenr_changed()
+{
+	init();
+}
+
+void ThresholdWidgetQt4::initUi()
+{
+	ui.setupUi(this);
+
+	activeslice = handler3D->active_slice();
+	bmphand = handler3D->get_activebmphandler();
+
+
+	auto mode_signal_mapping = new QSignalMapper(this);
+	mode_signal_mapping->setMapping(ui.mManualModeRadioButton, ui.mManualWidget);
+	mode_signal_mapping->setMapping(ui.mHistoModeRadioButton, ui.mHistoWidget);
+	mode_signal_mapping->setMapping(ui.mKMeansRadioButton, ui.mKmeansEMWidget);
+	mode_signal_mapping->setMapping(ui.mEMModeRadioButton, ui.mKmeansEMWidget);
+	QObject::connect(ui.mManualModeRadioButton, SIGNAL(clicked()), mode_signal_mapping, SLOT(map()));
+	QObject::connect(ui.mHistoModeRadioButton, SIGNAL(clicked()), mode_signal_mapping, SLOT(map()));
+	QObject::connect(ui.mKMeansRadioButton, SIGNAL(clicked()), mode_signal_mapping, SLOT(map()));
+	QObject::connect(ui.mEMModeRadioButton, SIGNAL(clicked()), mode_signal_mapping, SLOT(map()));
+	QObject::connect(mode_signal_mapping, SIGNAL(mapped(QWidget*)), ui.mModeStackedWidget, SLOT(setCurrentWidget(QWidget*)));
+
+	// init with manual mode
+	ui.mManualModeRadioButton->setChecked(true);
+	ui.mModeStackedWidget->setCurrentWidget(ui.mManualWidget);
+}
+
+void ThresholdWidgetQt4::updateUi()
+{	
+	auto range = get_range();
+	// manual
+	ui.mLoadBordersPushButton->setDisabled(hideparams);
+	ui.mSaveBordersPushButton->setDisabled(hideparams);
+	ui.mThresholdLowerLabel->setText(QString::number(range.first, 'g', 3));
+	ui.mThresholdUpperLabel->setText(QString::number(range.second, 'g', 3));
+	if (range.second != range.first) {
+		const int slider_value = static_cast<int>((threshs[ui.mManualLimitNrSpinBox->value()] - range.first) * 200 /
+			(range.second - range.first) + .5f);
+		ui.mThresholdHorizontalSlider->setValue(slider_value);
+		ui.mThresholdBorderLineEdit->setText(QString::number(threshs[ui.mManualLimitNrSpinBox->value()], 'g', 3));
+	}
+	
+	//ui.mWeightBorderLineEdit->setText(QString::number(threshs[sb_tissuenr->value()], 'g', 3));
+	ui.mManualLimitNrLabel->setEnabled(ui.mManualNrTissuesSpinBox->value() != 2);
+	ui.mManualLimitNrSpinBox->setEnabled(ui.mManualNrTissuesSpinBox->value() != 2);
+
+	// histo
+	ui.mSubsectionGroupBox->setDisabled(hideparams);
+	ui.mMinPixelsFrame->setDisabled(hideparams);
+
+	// kmeans
+	ui.mKMeansDimsLabel->setDisabled(hideparams);
+	ui.mKMeansDimsSpinBox->setDisabled(hideparams);
+	ui.mKMeansIterationsFrame->setDisabled(hideparams);
+	ui.mKMeansWeightHorizontalSlider->setValue(int(200 * weights[ui.mKMeansImageNrSpinBox->value() - 1]));
+	ui.mKMeansFilenameFrame->setEnabled(ui.mKMeansImageNrSpinBox->value() > 1);	
+	ui.mKMeansFilenameLineEdit_2->setText(ui.mKMeansImageNrSpinBox->value() > 1 ? filenames[ui.mKMeansImageNrSpinBox->value() - 2] : "");
+
+	// general
+	ui.mCenterFilenameLineEdit->setEnabled(ui.mUseCenterFileCheckBox->isChecked());
+	ui.mSelectCenterFilenamePushButton->setEnabled(ui.mUseCenterFileCheckBox->isChecked());
+}
+
+std::pair<float, float> ThresholdWidgetQt4::get_range() const
+{
+	std::pair<float, float> range(0, 0);
+	if (bmphand) {
+		Pair p;
+		bmphand->get_bmprange(&p);
+		range.first = p.low;
+		range.second = p.high;
+	}
+	return range;
+}

--- a/iSeg/ThresholdWidgetQt4.h
+++ b/iSeg/ThresholdWidgetQt4.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 The Foundation for Research on Information Technologies in Society (IT'IS).
+ * 
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ * 
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+#pragma once
+
+#include "Interface/WidgetInterface.h"
+
+#include "ui_ThresholdWidgetQt4.h"
+
+
+
+namespace iseg {
+
+class SlicesHandler;
+class bmphandler;
+
+class ThresholdWidgetQt4 : public WidgetInterface
+{
+	Q_OBJECT
+public:
+	explicit ThresholdWidgetQt4(SlicesHandler *hand3D, QWidget *parent,
+								const char* name, Qt::WindowFlags wFlags);
+	virtual ~ThresholdWidgetQt4();
+
+	virtual void init() override;
+	virtual void newloaded() override;
+	virtual void hideparams_changed() override;
+	// should be const'ed
+	virtual std::string GetName() override { return std::string("Threshold"); }
+	virtual QIcon GetIcon(QDir picdir) override { return QIcon(picdir.absFilePath(QString("thresholding.png"))); }
+	virtual FILE *SaveParams(FILE *fp, int version) override;
+	virtual FILE *LoadParams(FILE *fp, int version) override;
+
+private slots:
+	// manual
+	void on_mManualNrTissuesSpinBox_valueChanged(int newValue);
+	void on_mManualLimitNrSpinBox_valueChanged(int newValue);
+	void on_mLoadBordersPushButton_clicked();
+	void on_mSaveBordersPushButton_clicked();
+	void on_mThresholdHorizontalSlider_valueChanged(int newValue);
+	void on_mThresholdBorderLineEdit_editingFinished();
+
+	// histo
+	void on_mHistoPxSpinBox_valueChanged(int newValue);
+	void on_mHistoLxSpinBox_valueChanged(int newValue);
+	void on_mHistoPySpinBox_valueChanged(int newValue);
+	void on_mHistoLySpinBox_valueChanged(int newValue);
+	void on_mHistoMinPixelsSpinBox_valueChanged(int newValue);
+	void on_mHistoMinPixelsRatioHorizontalSlider_valueChanged(int newValue);
+
+	// kmeans
+	void on_mKMeansNrTissuesSpinBox_valueChanged(int newValue);
+	void on_mKMeansDimsSpinBox_valueChanged(int newValue);
+	void on_mKMeansImageNrSpinBox_valueChanged(int newValue);
+	void on_mKMeansWeightHorizontalSlider_valueChanged(int newValue);
+	void on_mKMeansFilenameLineEdit_editingFinished();
+	void on_mKMeansFilenamePushButton_clicked();
+	void on_mKMeansRRadioButton_clicked();
+	void on_mKMeansGRadioButton_clicked();
+	void on_mKMeansBRadioButton_clicked();
+	void on_mKMeansARadioButton_clicked();
+	void on_mKMeansIterationsSpinBox_valueChanged(int newValue);
+	void on_mKMeansConvergeSpinBox_valueChanged(int newValue);
+
+
+	// general
+	void on_mUseCenterFileCheckBox_toggled(bool newValue);
+	void on_mCenterFilenameLineEdit_editingFinished();
+	void on_mSelectCenterFilenamePushButton_clicked();
+
+	void on_mAllSlicesCheckBox_toggled(bool newValue);
+	void on_mExecutePushButton_clicked();
+
+private:
+	void on_tissuenr_changed(int i) override;
+	void on_slicenr_changed() override;
+	void initUi();
+	void updateUi();
+
+	std::pair<float, float> get_range() const;
+
+	bmphandler *bmphand = nullptr;
+	SlicesHandler *handler3D = nullptr;
+	unsigned short activeslice = std::numeric_limits<short>::max();
+	float threshs[21]; // ugly
+	float weights[20]; // ugly
+	float *bits[20]; // ugly
+	unsigned bits1[20]; // ugly
+	std::vector<QString> filenames;
+	Ui::ThresholdWidgetQt4 ui;
+
+};
+
+} // namespace iseg

--- a/iSeg/ThresholdWidgetQt4.h
+++ b/iSeg/ThresholdWidgetQt4.h
@@ -77,17 +77,20 @@ private slots:
 	void on_mAllSlicesCheckBox_toggled(bool newValue);
 	void on_mExecutePushButton_clicked();
 
+	// override
+	void bmp_changed();
+
 private:
 	void on_tissuenr_changed(int i) override;
 	void on_slicenr_changed() override;
 	void initUi();
 	void updateUi();
+	void resetThresholds();
+	void RGBA_changed();
 
 	std::pair<float, float> get_range() const;
 
-	bmphandler *bmphand = nullptr;
 	SlicesHandler *handler3D = nullptr;
-	unsigned short activeslice = std::numeric_limits<short>::max();
 	float threshs[21]; // ugly
 	float weights[20]; // ugly
 	float *bits[20]; // ugly

--- a/iSeg/ThresholdWidgetQt4.ui
+++ b/iSeg/ThresholdWidgetQt4.ui
@@ -482,24 +482,24 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QLabel" name="mKMeansFilenameLabel_2">
+               <widget class="QLabel" name="mKMeansFilenameLabel">
                 <property name="text">
                  <string>Filename:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QLineEdit" name="mKMeansFilenameLineEdit_2"/>
+               <widget class="QLineEdit" name="mKMeansFilenameLineEdit"/>
               </item>
               <item>
-               <widget class="QPushButton" name="mKMeansFilenamePushButton_2">
+               <widget class="QPushButton" name="mKMeansFilenamePushButton">
                 <property name="text">
                  <string>Select</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QFrame" name="mChannelFrame_2">
+               <widget class="QFrame" name="mChannelFrame">
                 <property name="frameShape">
                  <enum>QFrame::StyledPanel</enum>
                 </property>
@@ -511,28 +511,28 @@
                   <number>0</number>
                  </property>
                  <item>
-                  <widget class="QRadioButton" name="mKMeansRRadioButton_2">
+                  <widget class="QRadioButton" name="mKMeansRRadioButton">
                    <property name="text">
                     <string>R</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="mKMeansGRadioButton_2">
+                  <widget class="QRadioButton" name="mKMeansGRadioButton">
                    <property name="text">
                     <string>G</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="mKMeansBRadioButton_2">
+                  <widget class="QRadioButton" name="mKMeansBRadioButton">
                    <property name="text">
                     <string>B</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="mKMeansARadioButton_2">
+                  <widget class="QRadioButton" name="mKMeansARadioButton">
                    <property name="text">
                     <string>A</string>
                    </property>
@@ -666,6 +666,9 @@
           <widget class="QCheckBox" name="mAllSlicesCheckBox">
            <property name="text">
             <string>Apply to all slices</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/iSeg/ThresholdWidgetQt4.ui
+++ b/iSeg/ThresholdWidgetQt4.ui
@@ -1,0 +1,702 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ThresholdWidgetQt4</class>
+ <widget class="QWidget" name="ThresholdWidgetQt4">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>520</width>
+    <height>227</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="toolTip">
+   <string>Segment tissues based on thresholding techniques.</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_6">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QGroupBox" name="mModeGroupBox">
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <property name="title">
+        <string/>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QRadioButton" name="mManualModeRadioButton">
+          <property name="text">
+           <string>Manual</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="mHistoModeRadioButton">
+          <property name="text">
+           <string>Histo</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="mKMeansRadioButton">
+          <property name="text">
+           <string>k-means</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="mEMModeRadioButton">
+          <property name="text">
+           <string>EM</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QStackedWidget" name="mModeStackedWidget">
+         <property name="currentIndex">
+          <number>2</number>
+         </property>
+         <widget class="QWidget" name="mManualWidget">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="mManualNrTissuesLabel">
+               <property name="text">
+                <string>#Tissues</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="mManualNrTissuesSpinBox">
+               <property name="minimum">
+                <number>2</number>
+               </property>
+               <property name="maximum">
+                <number>30</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="mManualLimitNrLabel">
+               <property name="text">
+                <string>Limit-Nr:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="mManualLimitNrSpinBox">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="mLoadBordersPushButton">
+               <property name="text">
+                <string>Open...</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="mSaveBordersPushButton">
+               <property name="text">
+                <string>Save...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="mManualThresholdLabel">
+               <property name="text">
+                <string>Threshold:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="mThresholdLowerLabel">
+               <property name="text">
+                <string>xxxxxxx</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="mThresholdHorizontalSlider">
+               <property name="maximum">
+                <number>200</number>
+               </property>
+               <property name="singleStep">
+                <number>1</number>
+               </property>
+               <property name="value">
+                <number>200</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="mThresholdUpperLabel">
+               <property name="text">
+                <string>xxxxxxx</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="mThresholdBorderLineEdit"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mHistoWidget">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QGroupBox" name="mSubsectionGroupBox">
+             <property name="title">
+              <string>Subsection</string>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>px:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="mHistoPxSpinBox"/>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_9">
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="text">
+                   <string>py:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="mHistoPySpinBox"/>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <item>
+                 <widget class="QLabel" name="label_2">
+                  <property name="text">
+                   <string>lx</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="mHistoLxSpinBox"/>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_10">
+                <item>
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>ly:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="mHistoLySpinBox"/>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="3">
+               <spacer name="horizontalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QFrame" name="mMinPixelsFrame">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <property name="margin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="mHistoMinPixelsLabel">
+                <property name="text">
+                 <string>Min. Pixels:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="mHistoMinPixelsSpinBox">
+                <property name="maximum">
+                 <number>100000</number>
+                </property>
+                <property name="singleStep">
+                 <number>10</number>
+                </property>
+                <property name="value">
+                 <number>50</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="mHistoMinPixelsRatioLabel">
+                <property name="text">
+                 <string>Ratio:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="mHistoMinPixelsRatioHorizontalSlider">
+                <property name="maximum">
+                 <number>200</number>
+                </property>
+                <property name="value">
+                 <number>160</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mKmeansEMWidget">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_13">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <item>
+                <widget class="QLabel" name="mKMeansNrTissuesLabel">
+                 <property name="text">
+                  <string>#Tissues</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="mKMeansNrTissuesSpinBox">
+                 <property name="minimum">
+                  <number>2</number>
+                 </property>
+                 <property name="maximum">
+                  <number>30</number>
+                 </property>
+                 <property name="value">
+                  <number>2</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="mKMeansDimsLabel">
+                 <property name="text">
+                  <string>#Dims</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="mKMeansDimsSpinBox">
+                 <property name="prefix">
+                  <string/>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_14">
+               <item>
+                <widget class="QLabel" name="mKMeansImageNrLabel">
+                 <property name="text">
+                  <string>Image-Nr:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="mKMeansImageNrSpinBox">
+                 <property name="prefix">
+                  <string/>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>13</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_15">
+             <item>
+              <widget class="QLabel" name="mKMeansWeightLabel">
+               <property name="text">
+                <string>Weight:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="mKMeansWeightHorizontalSlider">
+               <property name="maximum">
+                <number>200</number>
+               </property>
+               <property name="value">
+                <number>200</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QFrame" name="mKMeansFilenameFrame">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_19">
+              <property name="margin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="mKMeansFilenameLabel_2">
+                <property name="text">
+                 <string>Filename:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="mKMeansFilenameLineEdit_2"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="mKMeansFilenamePushButton_2">
+                <property name="text">
+                 <string>Select</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="mChannelFrame_2">
+                <property name="frameShape">
+                 <enum>QFrame::StyledPanel</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_20">
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QRadioButton" name="mKMeansRRadioButton_2">
+                   <property name="text">
+                    <string>R</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="mKMeansGRadioButton_2">
+                   <property name="text">
+                    <string>G</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="mKMeansBRadioButton_2">
+                   <property name="text">
+                    <string>B</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="mKMeansARadioButton_2">
+                   <property name="text">
+                    <string>A</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QFrame" name="mKMeansIterationsFrame">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <property name="margin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="mKMeansIterationsLabel">
+                <property name="text">
+                 <string>#Iterations:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="mKMeansIterationsSpinBox">
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+                <property name="singleStep">
+                 <number>5</number>
+                </property>
+                <property name="value">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="mKMeansConvergeLabel">
+                <property name="text">
+                 <string>Converge:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="mKMeansConvergeSpinBox">
+                <property name="maximum">
+                 <number>100000</number>
+                </property>
+                <property name="singleStep">
+                 <number>100</number>
+                </property>
+                <property name="value">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QCheckBox" name="mUseCenterFileCheckBox">
+           <property name="text">
+            <string>Use InitCenters:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="mCenterFilenameLineEdit">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="mSelectCenterFilenamePushButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Select</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_18">
+         <item>
+          <widget class="QCheckBox" name="mAllSlicesCheckBox">
+           <property name="text">
+            <string>Apply to all slices</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="mExecutePushButton">
+           <property name="text">
+            <string>Execute</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- Migration of ThresholdWidget to Qt4
- Make use of QtDesigner - .ui file to design the UI instead of completely coding it as example
- Make use of automatic connection using the on_XXX_signalname() method signature
- Have one central updateUi method to update all the UI instead of having multiple calls everywhere that makes it very difficult to follow

This way of migrating is too much but should be taken as an example for new widgets as you really do not want to code layouts/buttons. We only want to code results of pressing a button, not the button itself.

closes #584