### PR TITLE
Fix mask source, minor changes (#123)

### DIFF
--- a/Data/ScopeExit.h
+++ b/Data/ScopeExit.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 The Foundation for Research on Information Technologies in Society (IT'IS).
+ * 
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ * 
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+
+#pragma once
+
+namespace iseg {
+
+/** This simple template class allows to execute arbitrary code when leaving a scope.
+
+		\note Instances can only be moved, not copied.
+	*/
+template <typename F>
+struct ScopeExit
+{
+    explicit ScopeExit(F f)
+        : f(std::move(f))
+        , m_Empty(false)
+    {}
+    ~ScopeExit()
+    {
+        if (!m_Empty)
+            f();
+    }
+
+    F f;
+
+    ScopeExit(ScopeExit && rhs) noexcept
+        : f(std::move(rhs.f))
+    {
+        rhs.m_Empty = true;
+        m_Empty = false;
+    }
+
+  private:
+    ScopeExit(const ScopeExit & rhs) = delete;
+    void operator=(const ScopeExit & rhs) = delete;
+    bool m_Empty;
+};
+
+/// Creates
+template <typename F>
+ScopeExit<F> MakeScopeExit(F f)
+{
+    return std::move(ScopeExit<F>(std::move(f)));
+};
+
+} // namespace iseg

--- a/iSeg/MainWindow.cpp
+++ b/iSeg/MainWindow.cpp
@@ -2559,18 +2559,17 @@ void MainWindow::ExecuteSaveimg()
 
 void MainWindow::ExecuteSaveprojas()
 {
-	DataSelection data_selection;
-	data_selection.bmp = true;
-	data_selection.work = true;
-	data_selection.tissues = true;
-	data_selection.tissueHierarchy = true;
-	emit BeginDataexport(data_selection, this);
-
 	QString savefilename = RecentPlaces::GetSaveFileName(this, "Save as", QString::null, "Projects (*.prj)");
-
-	if (!savefilename.isEmpty())
+	if (savefilename.length() > 4)
 	{
-		if (savefilename.length() <= 4 || !savefilename.endsWith(QString(".prj")))
+		DataSelection data_selection;
+		data_selection.bmp = true;
+		data_selection.work = true;
+		data_selection.tissues = true;
+		data_selection.tissueHierarchy = true;
+		emit BeginDataexport(data_selection, this);
+
+		if (!savefilename.endsWith(QString(".prj")))
 			savefilename.append(".prj");
 
 		m_MSaveprojfilename = savefilename;
@@ -2655,24 +2654,24 @@ void MainWindow::ExecuteSaveprojas()
 		QFile::rename(temp_file_name_without_extension + ".h5", source_file_name_without_extension + ".h5");
 
 		progress.setValue(num_tasks);
+
+		emit EndDataexport(this);
 	}
-	emit EndDataexport(this);
 }
 
 void MainWindow::ExecuteSavecopyas()
 {
-	DataSelection data_selection;
-	data_selection.bmp = true;
-	data_selection.work = true;
-	data_selection.tissues = true;
-	data_selection.tissueHierarchy = true;
-	emit BeginDataexport(data_selection, this);
-
-	QString savefilename = RecentPlaces::GetSaveFileName(this, "Save as", QString::null, "Projects (*.prj)");
-
-	if (!savefilename.isEmpty())
+	QString savefilename = RecentPlaces::GetSaveFileName(this, "Save copy as", QString::null, "Projects (*.prj)");
+	if (savefilename.length() > 4)
 	{
-		if (savefilename.length() <= 4 || !savefilename.endsWith(QString(".prj")))
+		DataSelection data_selection;
+		data_selection.bmp = true;
+		data_selection.work = true;
+		data_selection.tissues = true;
+		data_selection.tissueHierarchy = true;
+		emit BeginDataexport(data_selection, this);
+
+		if (!savefilename.endsWith(QString(".prj")))
 			savefilename.append(".prj");
 
 		FILE* fp = m_Handler3D->SaveProject(savefilename.ascii(), "xmf");
@@ -2705,8 +2704,9 @@ void MainWindow::ExecuteSavecopyas()
 		fp = SaveNotes(fp, save_proj_version);
 
 		fclose(fp);
+
+		emit EndDataexport(this);
 	}
-	emit EndDataexport(this);
 }
 
 void MainWindow::SaveSettings()


### PR DESCRIPTION
* fix: mask source was always acting on all slices

* if no file is selected, skip BeginDataexport/EndDataexport in SaveAs/SaveCopyAs

* morpho: limit number of threads for running all slices (2d)

Co-authored-by: Bryn Lloyd <lloyd@itis.swiss>